### PR TITLE
Add new role for SSM

### DIFF
--- a/cloudsplaining/shared/default-exclusions.yml
+++ b/cloudsplaining/shared/default-exclusions.yml
@@ -14,6 +14,7 @@ policies:
 roles:
   - "service-role*"
   - "aws-service-role*"
+  - "AWS-QuickSetup-StackSet-Local-AdministrationRole"
 users:
   - ""
 groups:


### PR DESCRIPTION
## What does this PR do?

Adding this role that is auto-generated by SSM when clicking on SSM's quick setup button for the first time. Policy perms only include AssumeRole for CloudFormation. AWS seems to be utilizing CloudFormation more to auto-deploy resources. 

There's an additional role "AWS-QuickSetup-StackSet-Local-ExecutionRole" created during this setup, which auto-adds the "AdministratorAccess" policy by default. That 2nd role was not included in this PR.

I've seen other examples of roles created using this prefix "AWS-QuickSetup*" for SSM. (AWS-QuickSetup-HostMgmtRole-*)

## What gif best describes this PR or how it makes you feel?

This is a hidden gem that's not well documented by AWS (I could be wrong...). 

Either way, PM's weren't thinking about security on this one.

## Completion checklist
- [ ] Additions and changes have unit tests
- [X] The pull request has been appropriately labeled using the provided PR labels
- [ ] GitHub actions automation is passing (`make test`, `make lint`, `make security-test`, `make test-js`)
- [ ] If the UI contents or JavaScript files have been modified, generate a new example report:

```bash
# Generate the updated Javascript bundle
make build-js

# Generate the example report
make generate-report
```

